### PR TITLE
Unarchive tar file preserving extended attributes and owners

### DIFF
--- a/containers/archlinux/tasks/main.yml
+++ b/containers/archlinux/tasks/main.yml
@@ -23,7 +23,10 @@
   unarchive:
     src: "{{ download_path }}/archlinux-bootstrap.tar.gz"
     dest: "{{ buildah_mount.stdout }}"
-    extra_opts: [--strip-components=1]
+    extra_opts:
+      - --strip-components=1
+      - --xattrs
+      - --numeric-owner
 - name: Copy list of pacman mirrors
   template:
     src: mirrorlist.j2


### PR DESCRIPTION
`--xattrs`
Enable extended attributes support

`--numeric-owner`
Restore numeric owners of the files rather than matching with usernames in the environment