### PR TITLE
Create a filter to convert key/value pairs into a list of options for CLI

### DIFF
--- a/containers/archlinux/filter_plugins/command.py
+++ b/containers/archlinux/filter_plugins/command.py
@@ -1,13 +1,14 @@
 from itertools import chain
 
 def build_list(options):
-    return list(chain.from_iterable(formatter(options)))
+    names, values = map(formatter, options.keys()), options.values()
+    return flatten(zip(names, values))
 
-def formatter(options):
-    def long_option(opt):
-        return ('--{}'.format(opt))
+def formatter(opt):
+    return '--{}'.format(opt)
 
-    return zip(map(long_option, options.keys()), options.values())
+def flatten(nested):
+    return list(chain.from_iterable(nested))
 
 class FilterModule(object):
 

--- a/containers/archlinux/filter_plugins/command.py
+++ b/containers/archlinux/filter_plugins/command.py
@@ -1,0 +1,17 @@
+from itertools import chain
+
+def to_list(options):
+    return list(chain.from_iterable(formatter(options)))
+
+def formatter(options):
+    def long_option(opt):
+        return ('--{}'.format(opt))
+
+    return zip(map(long_option, options.keys()), options.values())
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            'extra_opts': to_list
+        }

--- a/containers/archlinux/filter_plugins/command.py
+++ b/containers/archlinux/filter_plugins/command.py
@@ -1,6 +1,6 @@
 from itertools import chain
 
-def to_list(options):
+def build_list(options):
     return list(chain.from_iterable(formatter(options)))
 
 def formatter(options):
@@ -13,5 +13,5 @@ class FilterModule(object):
 
     def filters(self):
         return {
-            'extra_opts': to_list
+            'opts_list': build_list
         }

--- a/containers/archlinux/tasks/main.yml
+++ b/containers/archlinux/tasks/main.yml
@@ -11,7 +11,10 @@
     date: "{{ ansible_date_time.date | to_datetime('%Y-%m-%d') | to_day_1(month=-1, fmt='%Y.%m.%d') }}"
   when: download_result is failed
 - name: Create an empty container
-  command: buildah from scratch
+  command:
+    argv: "{{ ['buildah', 'from'] + options + ['scratch'] }}"
+  vars:
+    options: "{{ (buildah_extra_args | default({})).from | default({}) | opts_list }}"
   register: buildah_from
 - name: "{{ buildah_from.stdout }} created"
   set_fact:


### PR DESCRIPTION
This filter will allow to pass options for commands in a YAML dictionary.
```
ansible-playbook --extra-vars "@buildah-args.yml" playbook.yml
```
```yml
buildah_extra_args:
  from:
    name: barbaz
```
```
["--name", "barbaz"]
```