### PR TITLE
Remove task to copy resolvers file

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -9,7 +9,6 @@ Tasks
 `main.yml` does not include any. Load them on your playbook using `tasks_from`.
 
 - locale
-- nameservers
 - timezone
 
 Role Variables
@@ -19,9 +18,6 @@ Role Variables
 
 ```yaml
 system_locale: en_US.UTF-8
-nameservers:
-  default: 1.1.1.1
-  secondary: 8.8.8.8
 ```
 
 ### required

--- a/common/defaults/main.yml
+++ b/common/defaults/main.yml
@@ -1,5 +1,2 @@
 ---
 system_locale: en_US.UTF-8
-nameservers:
-  default: 1.1.1.1
-  secondary: 8.8.8.8

--- a/common/tasks/nameservers.yml
+++ b/common/tasks/nameservers.yml
@@ -1,6 +1,0 @@
----
-- name: Copy resolver configuration file
-  template:
-    src: resolv.conf.j2
-    dest: /etc/resolv.conf
-    mode: '0644'

--- a/common/templates/resolv.conf.j2
+++ b/common/templates/resolv.conf.j2
@@ -1,2 +1,0 @@
-nameserver {{ nameservers.default }}
-nameserver {{ nameservers.secondary }}


### PR DESCRIPTION
No longer needed by [`elixir-ide` playbooks](https://github.com/miquecg/elixir-ide).

Relates to #22.