### PR TITLE
Create workflows to lint roles on every PR and push to master

### DIFF
--- a/.github/workflows/lint-role-arch.yml
+++ b/.github/workflows/lint-role-arch.yml
@@ -4,6 +4,8 @@ name: arch_container
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths:
+      - 'containers/archlinux/**'
 
 jobs:
   lint:

--- a/.github/workflows/lint-role-arch.yml
+++ b/.github/workflows/lint-role-arch.yml
@@ -10,3 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Lint role arch_container
+        uses: ansible/ansible-lint-action@v4.1.0
+        with:
+          targets: containers/archlinux

--- a/.github/workflows/lint-role-arch.yml
+++ b/.github/workflows/lint-role-arch.yml
@@ -6,6 +6,11 @@ on:
     types: [opened, reopened, synchronize]
     paths:
       - 'containers/archlinux/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'containers/archlinux/**'
 
 jobs:
   lint:

--- a/.github/workflows/lint-role-arch.yml
+++ b/.github/workflows/lint-role-arch.yml
@@ -1,5 +1,5 @@
 ---
-name: lint arch_container
+name: arch_container
 
 on:
   pull_request:

--- a/.github/workflows/lint-role-arch.yml
+++ b/.github/workflows/lint-role-arch.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Lint role arch_container
-        uses: ansible/ansible-lint-action@v4.1.0
+        uses: ansible/ansible-lint-action@master
         with:
           targets: containers/archlinux

--- a/.github/workflows/lint-role-arch.yml
+++ b/.github/workflows/lint-role-arch.yml
@@ -1,0 +1,12 @@
+---
+name: lint arch_container
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2

--- a/.github/workflows/lint-role-common.yml
+++ b/.github/workflows/lint-role-common.yml
@@ -1,0 +1,23 @@
+---
+name: common
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'common/**'
+  push:
+    branches:
+      - master
+    paths:
+      - 'common/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint role common
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: common


### PR DESCRIPTION
### Issue
#27

### Example
https://github.community/t5/GitHub-Actions/pull-request-action-does-not-run-on-merge/m-p/43342#M5346

### Limitations
Anchors and aliases are not supported yet on GitHub workflows. Some degree of duplication has to be accepted for the moment.

https://github.community/t5/GitHub-Actions/Support-for-YAML-anchors/td-p/30336

Environment variables are only available for _actions_ or _commands_, thus it's not possible to use them for setting path filters on events.

> Commands run in actions or steps can create, read, and modify environment variables.

Not being allowed to filter affected paths on jobs or steps to create only one linting workflow.

https://github.community/t5/GitHub-Actions/Path-filtering-for-jobs-and-steps/td-p/33617